### PR TITLE
fix: Populate Start Menu from static app definitions

### DIFF
--- a/window/App.tsx
+++ b/window/App.tsx
@@ -8,6 +8,7 @@ import Desktop from './components/Desktop';
 import { ThemeContext, themes } from './theme';
 import { AppContext } from './contexts/AppContext';
 import { useWindowManager } from './hooks/useWindowManager';
+import { APP_DEFINITIONS } from '../components/apps';
 
 const App: React.FC = () => {
   const desktopRef = useRef<HTMLDivElement>(null);
@@ -77,7 +78,7 @@ const App: React.FC = () => {
 
 
   return (
-    <AppContext.Provider value={{ apps: discoveredApps }}>
+    <AppContext.Provider value={{ apps: APP_DEFINITIONS }}>
       <ThemeContext.Provider value={{ theme, setTheme: handleThemeChange }}>
         <div
           ref={desktopRef}


### PR DESCRIPTION
The Start Menu was previously populated by a dynamic list of applications discovered by the backend. This was causing some applications to not be displayed.

This change modifies the root App component to provide the static, complete `APP_DEFINITIONS` list to the `AppContext`. This ensures that the Start Menu and other components always have access to the full list of available applications, making the app's behavior more reliable and predictable.