### PR TITLE
fix: Correct icon rendering in Start Menu and Taskbar

### DIFF
--- a/window/components/StartMenu.tsx
+++ b/window/components/StartMenu.tsx
@@ -59,7 +59,7 @@ const StartMenu: React.FC<StartMenuProps> = ({ onOpenApp, onClose }) => {
                       className={`w-full flex items-center p-2 rounded-md transition-colors ${theme.startMenu.buttonHover}`}
                       title={app.name}
                     >
-                      <Icon iconName={app.icon} className="w-6 h-6 mr-4 flex-shrink-0" />
+                      <Icon iconName={app.id} className="w-6 h-6 mr-4 flex-shrink-0" />
                       <span className="text-sm text-left truncate">{app.name}</span>
                     </button>
                 ))}
@@ -86,7 +86,7 @@ const StartMenu: React.FC<StartMenuProps> = ({ onOpenApp, onClose }) => {
                       className={`flex flex-col items-center justify-center p-2 rounded-md transition-colors aspect-square ${theme.startMenu.pinnedButton}`}
                       title={app.name}
                     >
-                      <Icon iconName={app.icon} className="w-8 h-8 mb-1.5" />
+                      <Icon iconName={app.id} className="w-8 h-8 mb-1.5" />
                       <span className="text-xs text-center truncate w-full">{app.name}</span>
                     </button>
                 ))}
@@ -102,7 +102,7 @@ const StartMenu: React.FC<StartMenuProps> = ({ onOpenApp, onClose }) => {
                       className={`w-full flex items-center p-2 rounded-md transition-colors ${theme.startMenu.buttonHover}`}
                       title={app.name}
                     >
-                      <Icon iconName={app.icon} className="w-6 h-6 mr-3 flex-shrink-0" />
+                      <Icon iconName={app.id} className="w-6 h-6 mr-3 flex-shrink-0" />
                       <span className="text-sm text-left truncate">{app.name}</span>
                     </button>
                 ))}

--- a/window/components/Taskbar.tsx
+++ b/window/components/Taskbar.tsx
@@ -75,7 +75,7 @@ const Taskbar: React.FC<TaskbarProps> = ({ openApps, activeAppInstanceId, onTogg
                             ${isMinimized ? 'opacity-70' : ''}`}
                 title={appDef.name}
               >
-                <Icon iconName={appDef.icon} className="w-5 h-5" isSmall />
+                <Icon iconName={appDef.id} className="w-5 h-5" isSmall />
                 {isOpen && (
                   <span className={`absolute bottom-0 left-1/2 transform -translate-x-1/2 w-4 h-1 rounded-t-sm 
                                   ${isActive ? theme.taskbar.activeIndicator : isMinimized ? 'bg-gray-400' : 'bg-gray-500'}`}></span>


### PR DESCRIPTION
The Icon component expects a string 'iconName' prop, but was being passed the icon component function directly. This was caused by a previous change that switched the app list data source to the static APP_DEFINITIONS array.

This patch updates the StartMenu and Taskbar components to pass the correct app 'id' string to the Icon component, resolving the issue and allowing icons to render correctly.