### PR TITLE
fix: Correct 'themes' icon key in iconMap

### DIFF
--- a/window/components/icon/index.tsx
+++ b/window/components/icon/index.tsx
@@ -22,7 +22,7 @@ const iconMap: { [key: string]: React.FC<AppIconProps> } = {
     sftp: Icons.SftpIcon,
     appStore: Icons.AppStoreIcon,
     refresh: Icons.RefreshIcon,
-    theme: Icons.ThemeIcon,
+    themes: Icons.ThemeIcon,
     folder: Icons.FolderIcon,
     fileCode: Icons.FileCodeIcon,
     fileJson: Icons.FileJsonIcon,


### PR DESCRIPTION
The ThemeApp has an ID of 'themes', but the iconMap was using 'theme' as the key. This commit corrects the key in the iconMap to 'themes', resolving the final 'Icon not found' error.