### PR TITLE
fix: Prevent App Store from auto-refreshing

### DIFF
--- a/window/components/AppStore/index.tsx
+++ b/window/components/AppStore/index.tsx
@@ -4,7 +4,7 @@ import { StoreIcon, RefreshIcon, HyperIcon } from '../../../constants';
 
 const AppStoreApp: React.FC<AppComponentProps> = ({ setTitle }) => {
     const [availableApps, setAvailableApps] = useState<any[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
 
     const fetchAvailableApps = useCallback(async () => {
         setIsLoading(true);
@@ -25,8 +25,7 @@ const AppStoreApp: React.FC<AppComponentProps> = ({ setTitle }) => {
 
     useEffect(() => {
         setTitle('App Store');
-        fetchAvailableApps();
-    }, [setTitle, fetchAvailableApps]);
+    }, [setTitle]);
 
     const handleInstall = async (app: any) => {
         try {

--- a/window/components/AppStoreApp.tsx
+++ b/window/components/AppStoreApp.tsx
@@ -5,7 +5,7 @@ import * as FsService from '../../services/filesystemService';
 
 const AppStoreApp: React.FC<AppComponentProps> = ({ setTitle }) => {
     const [availableApps, setAvailableApps] = useState<any[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
 
     const fetchAvailableApps = useCallback(async () => {
         setIsLoading(true);
@@ -26,8 +26,7 @@ const AppStoreApp: React.FC<AppComponentProps> = ({ setTitle }) => {
 
     useEffect(() => {
         setTitle('App Store');
-        fetchAvailableApps();
-    }, [setTitle, fetchAvailableApps]);
+    }, [setTitle]);
 
     const handleInstall = async (app: any) => {
         try {


### PR DESCRIPTION
This commit addresses user feedback that the App Store component was constantly refreshing and causing a "flashing" effect.

The `useEffect` hook in the `AppStoreApp` component was previously fetching the list of available applications every time the component rendered. This has been changed so that the app list is no longer fetched automatically on mount.

The list of apps will now only be fetched when the user explicitly clicks the "Refresh" button inside the App Store, or after an application has been installed. This provides a more stable user experience and resolves the reported flashing.