### PR TITLE
fix: Resolve infinite loop in useWindowManager hook

### DIFF
--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -108,9 +108,9 @@ export const useWindowManager = (desktopRef: React.RefObject<HTMLDivElement>) =>
       initialData: initialData,
     };
 
-    setOpenApps(prev => [...prev, newApp]);
+    setOpenApps(currentOpenApps => [...currentOpenApps, newApp]);
     setActiveAppInstanceId(instanceId);
-  }, [appDefinitions, openApps, nextZIndex]);
+  }, [appDefinitions, nextZIndex]);
 
   const focusApp = useCallback((instanceId: string) => {
     if (activeAppInstanceId === instanceId) return;


### PR DESCRIPTION
This commit fixes a critical bug that caused an infinite re-render loop (`Maximum update depth exceeded`) when opening applications, particularly noticeable when opening the App Store.

The `openApp` function in the `useWindowManager` hook had a dependency on the `openApps` state variable while also calling `setOpenApps`. This created a dependency cycle.

The fix is to use the functional update form of `setState` (`setOpenApps(currentOpenApps => ...)`), which removes the need for `openApps` to be in the `useCallback` dependency array, breaking the infinite loop.

This commit also includes all previous fixes related to the dynamic app store architecture and icon handling.