### PR TITLE
fix: Prevent port conflicts when launching external apps

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -42,13 +42,18 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
-    setupInitialFilesystem();
-    initializeIpcHandlers();
-    
-    startApiServer();
-    startTerminusServer();
-    startSftpServer();
-    startChrome3Proxy(); // Start the new SOCKS5 proxy client for Chrome 3
+    const isChildInstance = process.argv.includes('--launched-by-host');
+
+    // Only the main instance should run servers and initial setup
+    if (!isChildInstance) {
+        setupInitialFilesystem();
+        initializeIpcHandlers();
+
+        startApiServer();
+        startTerminusServer();
+        startSftpServer();
+        startChrome3Proxy(); // Start the new SOCKS5 proxy client for Chrome 3
+    }
     
     // Apply header stripping to enable loading restricted sites in webviews
     setupHeaderStripping('persist:chrome1');

--- a/main/launcher.js
+++ b/main/launcher.js
@@ -8,7 +8,7 @@ function launchExternalAppByPath(relativeAppPath, args = []) {
         const appPath = path.join(FS_ROOT, relativeAppPath);
         const appDir = path.dirname(appPath);
 
-        const spawnArgs = ['.', ...args];
+        const spawnArgs = ['.', '--launched-by-host', ...args];
         console.log(`Attempting to launch external app from directory: ${appDir} with args: ${spawnArgs.join(' ')}`);
         
         const child = spawn(process.execPath, spawnArgs, {


### PR DESCRIPTION
This commit resolves a critical `EADDRINUSE` (Address already in use) crash that occurred when launching external applications from the App Store.

The root cause was that external apps, when launched, were re-running the main application's startup script (`main/index.js`) and attempting to start backend servers (`api.js`, `ws-terminus.js`, etc.) on ports that were already in use by the main application instance.

The fix implements a flag-based system to differentiate between the main 'OS' instance and a child application instance:
1.  **`main/launcher.js`**: Now adds a `--launched-by-host` command-line flag when spawning a new external app process.
2.  **`main/index.js`**: Now checks for the presence of the `--launched-by-host` flag at startup. If the flag is present, it skips the initialization of all backend servers, thus preventing any port conflicts.

This ensures that only the primary instance of the application runs the necessary background services, allowing external apps to launch and run correctly without crashing.