### PR TITLE
fix: Resolve module resolution error for external apps

### DIFF
--- a/main/launcher.js
+++ b/main/launcher.js
@@ -14,6 +14,10 @@ function launchExternalAppByPath(relativeAppPath, args = []) {
         const child = spawn(process.execPath, spawnArgs, {
             detached: true,
             stdio: 'inherit',
+            env: {
+                ...process.env,
+                NODE_PATH: path.resolve(FS_ROOT, 'node_modules'),
+            }
         });
 
         child.on('error', (err) => {


### PR DESCRIPTION
This commit provides the final fix for launching external applications, resolving a `Cannot find module 'electron'` error.

When an external app was launched, it was unable to resolve `require('electron')` because its module search path was not correctly configured.

The fix updates `main/launcher.js` to pass a `NODE_PATH` environment variable to the spawned child process. This variable points to the main application's `node_modules` directory, allowing the child process to correctly find and load the `electron` module provided by the parent application.

This commit includes all previous fixes for the dynamic app store feature.