### PR TITLE
refactor: Launch external apps via 'npm start'

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -42,18 +42,13 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
-    const isChildInstance = process.argv.includes('--launched-by-host');
+    setupInitialFilesystem();
+    initializeIpcHandlers();
 
-    // Only the main instance should run servers and initial setup
-    if (!isChildInstance) {
-        setupInitialFilesystem();
-        initializeIpcHandlers();
-
-        startApiServer();
-        startTerminusServer();
-        startSftpServer();
-        startChrome3Proxy(); // Start the new SOCKS5 proxy client for Chrome 3
-    }
+    startApiServer();
+    startTerminusServer();
+    startSftpServer();
+    startChrome3Proxy(); // Start the new SOCKS5 proxy client for Chrome 3
     
     // Apply header stripping to enable loading restricted sites in webviews
     setupHeaderStripping('persist:chrome1');


### PR DESCRIPTION
This commit provides the final, definitive fix for launching external applications, implementing a new, more robust strategy suggested by the user.

Previously, the launcher attempted to run the external app's code using the main application's Electron process. This created numerous and complex module resolution and pathing issues.

The new implementation in `main/launcher.js` now spawns a shell process that executes `npm start` within the external application's own directory. This correctly treats the external app as a separate, self-contained project, leveraging its own dependencies and start script. This is a much cleaner and more reliable approach.

Additionally, the `--launched-by-host` flag and its corresponding check in `main/index.js` have been removed, as they are no longer necessary with this new architecture, simplifying the main application's startup logic.