### PR TITLE
fix: Correctly generate icon property in .tsx template

### DIFF
--- a/main/api.js
+++ b/main/api.js
@@ -93,7 +93,7 @@ const ${componentName}: React.FC<AppComponentProps> = () => {
 export const appDefinition: AppDefinition = {
   id: '${id}',
   name: '${name}',
-  icon: HyperIcon, // Assign a generic icon
+  icon: 'hyper', // Assign a generic icon name as a string
   isExternal: true,
   externalPath: '${appPath}',
   component: ${componentName},


### PR DESCRIPTION
This commit resolves the final known bug, an `Icon not found` error that occurred after installing a new application.

The root cause was that the `.tsx` file generation template in `main/api.js` was creating an `appDefinition` that assigned the `icon` property to a component reference (`HyperIcon`) instead of a string literal (`'hyper'`). This violated the application's type system and caused the generic `<Icon>` component to fail.

The fix updates the template string to use the correct string literal for the icon name. This ensures that all dynamically generated application definitions are valid and that their icons can be rendered correctly.

This completes the dynamic app store feature.