### PR TITLE
fix: Use correct icon property in Start Menu and Taskbar

### DIFF
--- a/window/components/StartMenu.tsx
+++ b/window/components/StartMenu.tsx
@@ -59,7 +59,7 @@ const StartMenu: React.FC<StartMenuProps> = ({ onOpenApp, onClose }) => {
                       className={`w-full flex items-center p-2 rounded-md transition-colors ${theme.startMenu.buttonHover}`}
                       title={app.name}
                     >
-                      <Icon iconName={app.id} className="w-6 h-6 mr-4 flex-shrink-0" />
+                      <Icon iconName={app.icon} className="w-6 h-6 mr-4 flex-shrink-0" />
                       <span className="text-sm text-left truncate">{app.name}</span>
                     </button>
                 ))}
@@ -86,7 +86,7 @@ const StartMenu: React.FC<StartMenuProps> = ({ onOpenApp, onClose }) => {
                       className={`flex flex-col items-center justify-center p-2 rounded-md transition-colors aspect-square ${theme.startMenu.pinnedButton}`}
                       title={app.name}
                     >
-                      <Icon iconName={app.id} className="w-8 h-8 mb-1.5" />
+                      <Icon iconName={app.icon} className="w-8 h-8 mb-1.5" />
                       <span className="text-xs text-center truncate w-full">{app.name}</span>
                     </button>
                 ))}
@@ -102,7 +102,7 @@ const StartMenu: React.FC<StartMenuProps> = ({ onOpenApp, onClose }) => {
                       className={`w-full flex items-center p-2 rounded-md transition-colors ${theme.startMenu.buttonHover}`}
                       title={app.name}
                     >
-                      <Icon iconName={app.id} className="w-6 h-6 mr-3 flex-shrink-0" />
+                      <Icon iconName={app.icon} className="w-6 h-6 mr-3 flex-shrink-0" />
                       <span className="text-sm text-left truncate">{app.name}</span>
                     </button>
                 ))}

--- a/window/components/Taskbar.tsx
+++ b/window/components/Taskbar.tsx
@@ -75,7 +75,7 @@ const Taskbar: React.FC<TaskbarProps> = ({ openApps, activeAppInstanceId, onTogg
                             ${isMinimized ? 'opacity-70' : ''}`}
                 title={appDef.name}
               >
-                <Icon iconName={appDef.id} className="w-5 h-5" isSmall />
+                <Icon iconName={appDef.icon} className="w-5 h-5" isSmall />
                 {isOpen && (
                   <span className={`absolute bottom-0 left-1/2 transform -translate-x-1/2 w-4 h-1 rounded-t-sm 
                                   ${isActive ? theme.taskbar.activeIndicator : isMinimized ? 'bg-gray-400' : 'bg-gray-500'}`}></span>


### PR DESCRIPTION
This commit resolves the final `Icon not found` error, which occurred because the Start Menu and Taskbar components were incorrectly using the application's `id` as the icon name instead of the designated `icon` property from the `appDefinition`.

This was the last remaining inconsistency in the icon handling system.

Changes:
- Modified `StartMenu.tsx` to use `app.icon` when rendering icons for pinned, recommended, and "all apps" lists.
- Modified `Taskbar.tsx` to use `appDef.icon` when rendering taskbar icons.

This ensures that dynamically installed applications, which are assigned a generic icon name like 'hyper', will display correctly throughout the entire OS UI.

This commit completes the work on the dynamic app store feature, which is now fully functional and robust.