### PR TITLE
debug: Capture stderr from external app launch process

### DIFF
--- a/main/launcher.js
+++ b/main/launcher.js
@@ -14,17 +14,22 @@ function launchExternalAppByPath(relativeAppPath, args = []) {
         const child = spawn('npm', ['start'], {
             cwd: appDir,
             detached: true,
-            stdio: 'ignore', // Use 'ignore' to prevent stdio pipes from keeping the process alive
-            shell: true, // Important to use shell for 'npm start' on all platforms
+            stdio: 'pipe', // We use 'pipe' to capture stderr
+            shell: true,
+        });
+
+        // Log any errors from the child process
+        child.stderr.on('data', (data) => {
+            console.error(`[${path.basename(appDir)}] stderr: ${data}`);
         });
 
         child.on('error', (err) => {
-            console.error(`Failed to start subprocess for ${appDir}. Error: ${err.message}`);
+            console.error(`[Launcher] Failed to start subprocess for ${appDir}. Error: ${err.message}`);
         });
 
         child.on('exit', (code, signal) => {
             if (code !== 0) {
-                console.error(`Subprocess for ${appDir} exited with code ${code} and signal ${signal}`);
+                console.error(`[Launcher] Subprocess for ${appDir} exited with code ${code} and signal ${signal}`);
             }
         });
 


### PR DESCRIPTION
This commit updates the application launcher to provide better debugging for the final remaining issue where external apps fail to launch silently.

The `stdio` option for the spawned process in `main/launcher.js` has been changed from `'ignore'` to `'pipe'`. A listener has been added to the child process's `stderr` stream to capture any error output and log it to the main application's console.

This change will not fix the underlying launch failure, but it will make the error visible, allowing for a precise diagnosis of the final problem.