### PR TITLE
fix: Resolve ReferenceError crash in useWindowManager

### DIFF
--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -18,8 +18,8 @@ export const useWindowManager = (desktopRef: React.RefObject<HTMLDivElement>) =>
   }, []);
 
   useEffect(() => {
-    loadApps();
-  }, [loadApps]);
+    loadAndSetApps();
+  }, [loadAndSetApps]);
 
   const getNextPosition = (appWidth: number, appHeight: number) => {
     const desktopWidth = desktopRef.current?.clientWidth || window.innerWidth;


### PR DESCRIPTION
This commit fixes a critical `ReferenceError` that caused the entire application to crash on startup.

The bug was a simple typo in `useWindowManager.ts`. A function was renamed from `loadApps` to `loadAndSetApps`, but the `useEffect` hook that calls it was not updated, resulting in a call to an undefined function.

This commit corrects the function call, resolving the crash. This should restore the application to a fully functional state.